### PR TITLE
Update Grafana to 9.3.1 and enable Parca core data source

### DIFF
--- a/grafana-config.yaml
+++ b/grafana-config.yaml
@@ -17,6 +17,7 @@ stringData:
     disable_login_form = true
     [auth.anonymous]
     enabled = true
+    org_role = Editor
     [auth.basic]
     enabled = false
     [security]
@@ -26,3 +27,5 @@ stringData:
     domain = demo.parca.dev
     root_url = https://demo.parca.dev/grafana/
     serve_from_sub_path = true
+    [feature_toggles]
+    enable = flameGraph

--- a/grafana-datasources.yaml
+++ b/grafana-datasources.yaml
@@ -15,11 +15,17 @@ stringData:
         {
           "access": "proxy",
           "editable": false,
-          "name": "Parca",
+          "name": "Parca - PolarSignals",
           "orgId": 1,
           "type": "parca-datasource",
           "version": 1,
           "jsonData": {APIEndpoint: "https://demo.parca.dev"}
+        },
+        {
+          "name": "Parca - Grafana",
+          "type": "parca",
+          "url": "https://demo.parca.dev",
+          "editable": false
         }
       ]
     }

--- a/grafana-deployment.yaml
+++ b/grafana-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: grafana
     spec:
       containers:
-      - image: grafana/grafana:9.2.1
+      - image: grafana/grafana:9.3.1
         name: grafana
         env:
           - name: GF_INSTALL_PLUGINS


### PR DESCRIPTION
Example:

https://demo.parca.dev/grafana/explore?orgId=1&left=%7B%22datasource%22:%22P9B4EE85E4B3B7421%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22parca%22,%22uid%22:%22P9B4EE85E4B3B7421%22%7D,%22labelSelector%22:%22%7Bnamespace%3D%5C%22monitoring%5C%22,container%3D%5C%22prometheus%5C%22%7D%22,%22queryType%22:%22both%22,%22profileTypeId%22:%22parca_agent_cpu:samples:count:cpu:nanoseconds:delta%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D