### PR TITLE
feat(scaleway): bump Kubernetes to v1.27

### DIFF
--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -2,7 +2,7 @@ resource "scaleway_k8s_cluster" "parca_demo" {
   name                        = "parca-demo"
   type                        = "kapsule"
   description                 = ""
-  version                     = "1.24"
+  version                     = "1.27"
   cni                         = "cilium"
   delete_additional_resources = false
 


### PR DESCRIPTION
Correcting drift, had been done through the console.

Closes #8